### PR TITLE
Walkthrough improvement

### DIFF
--- a/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
+++ b/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
@@ -172,8 +172,6 @@ Use [`Viewer#on`](https://github.com/bpmn-io/bpmn-js/blob/master/lib/Viewer.js#L
 
 The [modeler example](https://github.com/bpmn-io/bpmn-js-examples/tree/master/modeler) covers all necessary steps needed to consume bpmn-js via npm and create a BPMN editor application around it. This includes additional steps needed for bundling the application for the browser.
 
-If you would like to create your own pre-packaged version of your custom modeler refer to the [custom-bundle](https://github.com/bpmn-io/bpmn-js-examples/tree/master/custom-bundle) example.
-
 
 ### Extending the Modeler
 
@@ -209,6 +207,13 @@ Other examples for extensions are:
 * [Custom shape rendering](https://github.com/bpmn-io/bpmn-js-nyan)
 
 Check out the [bpmn-js-examples project](https://github.com/bpmn-io/bpmn-js-examples) for many more toolkit extension show cases.
+
+
+### Building a Custom Distribution
+
+If you would like to create your own pre-packaged version of your custom modeler or viewer refer to the [custom-bundle](https://github.com/bpmn-io/bpmn-js-examples/tree/master/custom-bundle) example.
+
+This may make sense if you carried out heavy customizations that you would like to ship to your users in simple way.
 
 
 <div class="h1 page-header" id="bpmn-js-internals">

--- a/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
+++ b/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
@@ -1,3 +1,9 @@
+<style>
+  h3, .h3 {
+    margin-top: 30px;
+  }
+</style>
+
 <div class="h1 page-header" id="introduction">
   A Quick Introduction
 </div>

--- a/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
+++ b/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
@@ -192,9 +192,9 @@ var modeler = new Modeler({
 ```
 
 A _module_ (cf. [Module System section](#module-system)) is a unit that defines one or more named _services_.
-These services contribte functionality to bpmn-js, i.e. by hooking into the diagram life-cycle.
+These services configure bpmn-js or provide additional functionality, i.e. by hooking into the diagram life-cycle.
 
-Some modules, such as [diagram-js-origin](https://github.com/bpmn-io/diagram-js-origin) or [diagram-js-minimap](https://github.com/bpmn-io/diagram-js-minimap) contribute generic user interface extensions to the diagram.
+Some modules, such as [diagram-js-origin](https://github.com/bpmn-io/diagram-js-origin) or [diagram-js-minimap](https://github.com/bpmn-io/diagram-js-minimap) provide generic user interface additions.
 Built-in bpmn-js modules, such as [bpmn rules](https://github.com/bpmn-io/bpmn-js/blob/master/lib/features/rules) or [modeling](https://github.com/bpmn-io/bpmn-js/tree/master/lib/features/modeling) provide highly BPMN specific functionality.
 
 One common way to extend the BPMN modeler is to add [custom modeling rules](https://github.com/bpmn-io/bpmn-js-examples/tree/master/custom-modeling-rules).

--- a/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
+++ b/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
@@ -153,7 +153,7 @@ When embedding the modeler into a webpage include the [diagram-js stylesheet](ht
 ### Hooking into Life-Cycle Events
 
 Events allow you to hook into the life-cycle of the modeler as well as diagram interaction.
-The following snipped shows how changed elements and modeling operations in general can be captured.
+The following snippet shows how changed elements and modeling operations in general can be captured.
 
 ```javascript
 modeler.on('commandStack.changed', function() {
@@ -168,10 +168,7 @@ modeler.on('element.changed', function(event) {
 });
 ```
 
-Use [`Viewer#on`](https://github.com/bpmn-io/bpmn-js/blob/master/lib/Viewer.js#L365) to register for events or the [`EventBus`](https://github.com/bpmn-io/diagram-js/blob/master/lib/core/EventBus.js) inside extension modules.
-
-The [modeler example](https://github.com/bpmn-io/bpmn-js-examples/tree/master/modeler) covers all necessary steps needed to consume bpmn-js via npm and create a BPMN editor application around it. This includes additional steps needed for bundling the application for the browser.
-
+Use [`Viewer#on`](https://github.com/bpmn-io/bpmn-js/blob/master/lib/Viewer.js#L403) to register for events or the [`EventBus`](https://github.com/bpmn-io/diagram-js/blob/master/lib/core/EventBus.js) inside extension modules. Stop listening for events using the [`Viewer#off`](https://github.com/bpmn-io/bpmn-js/blob/master/lib/Viewer.js#L413) method. Check out the [interaction example](https://github.com/bpmn-io/bpmn-js-examples/tree/master/interaction) to see listening for events in action.
 
 ### Extending the Modeler
 
@@ -280,7 +277,7 @@ export default {
 };
 ```
 
-The definition tells the DI infrastructure that the service is called `myLoggingPlugin` `{1}`, that it depends on the diagram-js core module `{2}` and that the service should be initialized upon diagram creation `{3}`.
+The definition tells the DI infrastructure that the service is called `myLoggingPlugin` `{1}`, that it depends on the diagram-js core module `{2}` and that the service should be initialized upon diagram creation `{3}`. For more details have a look at the [didi documentation](https://github.com/nikku/didi/blob/master/README.md).
 
 We may now bootstrap diagram-js, passing the our custom module:
 

--- a/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
+++ b/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
@@ -150,6 +150,31 @@ When embedding the modeler into a webpage include the [diagram-js stylesheet](ht
 ```
 
 
+### Hooking into Life-Cycle Events
+
+Events allow you to hook into the life-cycle of the modeler as well as diagram interaction.
+The following snipped shows how changed elements and modeling operations in general can be captured.
+
+```javascript
+modeler.on('commandStack.changed', function() {
+  // user modeled something or
+  // performed a undo/redo operation
+});
+
+modeler.on('element.changed', function(event) {
+  var element = event.element;
+
+  // the element got changed by the users
+});
+```
+
+Use [`Viewer#on`](https://github.com/bpmn-io/bpmn-js/blob/master/lib/Viewer.js#L365) to register for events or the [`EventBus`](https://github.com/bpmn-io/diagram-js/blob/master/lib/core/EventBus.js) inside extension modules.
+
+The [modeler example](https://github.com/bpmn-io/bpmn-js-examples/tree/master/modeler) covers all necessary steps needed to consume bpmn-js via npm and create a BPMN editor application around it. This includes additional steps needed for bundling the application for the browser.
+
+If you would like to create your own pre-packaged version of your custom modeler refer to the [custom-bundle](https://github.com/bpmn-io/bpmn-js-examples/tree/master/custom-bundle) example.
+
+
 ### Extending the Modeler
 
 You may use the `additionalModules` option to extend the `Viewer` and [`Modeler`](https://github.com/bpmn-io/bpmn-js/blob/master/lib/Modeler.js) on creation. This allows you to pass custom _modules_ that amend or replace exising functionality.
@@ -184,31 +209,6 @@ Other examples for extensions are:
 * [Custom shape rendering](https://github.com/bpmn-io/bpmn-js-nyan)
 
 Check out the [bpmn-js-examples project](https://github.com/bpmn-io/bpmn-js-examples) for many more toolkit extension show cases.
-
-
-### Hooking into Life-Cycle Events
-
-Events allow you to hook into the life-cycle of the modeler as well as diagram interaction.
-The following snipped shows how changed elements and modeling operations in general can be captured.
-
-```javascript
-modeler.on('commandStack.changed', function() {
-  // user modeled something or
-  // performed a undo/redo operation
-});
-
-modeler.on('element.changed', function(event) {
-  var element = event.element;
-
-  // the element got changed by the users
-});
-```
-
-Use [`Viewer#on`](https://github.com/bpmn-io/bpmn-js/blob/master/lib/Viewer.js#L365) to register for events or the [`EventBus`](https://github.com/bpmn-io/diagram-js/blob/master/lib/core/EventBus.js) inside extension modules.
-
-The [modeler example](https://github.com/bpmn-io/bpmn-js-examples/tree/master/modeler) covers all necessary steps needed to consume bpmn-js via npm and create a BPMN editor application around it. This includes additional steps needed for bundling the application for the browser.
-
-If you would like to create your own pre-packaged version of your custom modeler refer to the [custom-bundle](https://github.com/bpmn-io/bpmn-js-examples/tree/master/custom-bundle) example.
 
 
 <div class="h1 page-header" id="bpmn-js-internals">


### PR DESCRIPTION
This fills the missing pieces in the bpmn-js walkthrough section:

* fills section on modules
* example how to extend bpmn-js with existing module
* new section on building modeler distribution
* minor restructuring

This should pretty much address concerns like [this](https://forum.bpmn.io/t/questions-about-module-system-and-architecture-of-camunda-modeler/2181) or [this](https://forum.bpmn.io/t/how-to-register-custom-service-for-injection/2534/4).