### PR TITLE
chore(site): add ability to generate forward links

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,6 +109,7 @@ module.exports = function(grunt) {
       main: {
         files: {
           '<%= config.dist %>/': ['<%= config.src %>/pages/*.hbs'],
+          '<%= config.dist %>/l/': ['<%= config.src %>/links/*.html'],
           '<%= config.dist %>/about/': ['<%= config.src %>/pages/about/*.hbs'],
           '<%= config.dist %>/modeler/': ['<%= config.src %>/pages/modeler/*.hbs'],
           '<%= config.dist %>/license/': ['<%= config.src %>/pages/license/*.hbs'],

--- a/src/links/dmn-compatibility.html
+++ b/src/links/dmn-compatibility.html
@@ -1,0 +1,5 @@
+---
+title: DMN Compatibility
+url: https://github.com/bpmn-io/dmn-js-examples/tree/master/dmn-compatibility
+layout: link.hbs
+---

--- a/src/templates/layouts/link.hbs
+++ b/src/templates/layouts/link.hbs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{#if title}}{{title}} | {{/if}}{{site.title}}</title>
+  <meta http-equiv="refresh" content="0; url={{url}}">
+</head>
+<body>
+  <code>Redirecting to {{url}}.</code>
+</body>
+</html>


### PR DESCRIPTION
Allows us to point users to semantically named links, i.e. in the
context of https://github.com/bpmn-io/dmn-js/issues/471