### PR TITLE
Use fetch instead of XHR in walkthrough example

### DIFF
--- a/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
+++ b/src/pages/toolkit/bpmn-js/walkthrough/walkthrough.md
@@ -101,21 +101,22 @@ This can be accomplished using plain JavaScript (as seen below) or via utility l
 
 ```html
 <script>
-  const xhr = new XMLHttpRequest();
+function fetchDiagram(url) {
+  return fetch(url).then(response => response.text());
+}
 
-  xhr.onreadystatechange = async () => {
-    if (xhr.readyState === 4) {
-      try {
-        await viewer.importXML(xhr.response);
-        // ...
-      } catch (err) {
-        // ...
-      }
-    }
-  };
+async function run() {
+  const diagram = await fetchDiagram('path-to-diagram.bpmn');
 
-  xhr.open('GET', 'path-to-diagram.bpmn', true);
-  xhr.send(null);
+  try {
+    await viewer.importXML(diagram);
+    // ...
+  } catch (err) {
+    // ...
+  }
+}
+
+run();
 </script>
 ```
 


### PR DESCRIPTION
This PR replaces the outdated XMLHttpRequest implementation with the more recent fetch() function.