### PR TITLE
feat: link and improve license page

### DIFF
--- a/src/pages/license/index.hbs
+++ b/src/pages/license/index.hbs
@@ -1,37 +1,37 @@
 ---
 title: License
+description: 'This license ("bpmn.io License") governs use of our toolkits bpmn-js, dmn-js, and cmmn-js.'
 ---
 
 <div class="row">
   <div class="col-md-12">
 
-    <h2 class="page-header">
-      bpmn.io License
-    </h2>
+    <pre>
+      <code>
+Copyright (c) 2014-present Camunda Services GmbH
 
-    <p>
-      Copyright (c) 2014-present camunda Services GmbH
-    </p>
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
 
-    <p>
-      Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-    </p>
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-    <p>
-      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-    </p>
+<strong>The source code responsible for displaying the bpmn.io project watermark that
+links back to https://bpmn.io as part of rendered diagrams MUST NOT be
+removed or changed. When this software is being used in a website or application,
+the watermark must stay fully visible and not visually overlapped by other elements.</strong>
 
-    <p>
-      <strong>
-        The source code responsible for displaying the bpmn.io project watermark that
-        links back to https://bpmn.io as part of rendered diagrams MUST NOT be
-        removed or changed. When this software is being used in a website or application,
-        the watermark must stay fully visible and not visually overlapped by other elements.
-      </strong>
-    </p>
-
-    <p>
-      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-    </p>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+      </code>
+    </pre>
   </div>
 </div>

--- a/src/templates/partials/footer.hbs
+++ b/src/templates/partials/footer.hbs
@@ -18,6 +18,7 @@ component: footer
     <ul class="footer-links muted">
       <li><a href="{{relative page.dest "dist/about"}}">About</a></li>
       <li><a href="https://camunda.com/career/">Work with us</a></li>
+      <li><a href="{{relative page.dest "dist/license/"}}">License</a></li>
       <li><a href="{{relative page.dest "dist/legal/imprint.html"}}">Imprint</a></li>
       <li><a href="{{relative page.dest "dist/legal/privacy.html"}}">Privacy Policy</a></li>
     </ul>


### PR DESCRIPTION
Links our license ("bpmn.io License") from the site footer.