### PR TITLE
chore(about): remove <camunda open source company>

### DIFF
--- a/src/pages/about/index.hbs
+++ b/src/pages/about/index.hbs
@@ -120,7 +120,7 @@ description: 'Learn about the bpmn.io project, its creators, origins, and BPMN.'
     </p>
 
     <p>
-      <a href="http://camunda.com">Camunda</a> is a company with a long track record in BPM. For more than five years we have been helping customers all over the world to apply business process management (BPM) in an effective way. In 2013 we launched <a href="http://camunda.org">Camunda</a>, an open source, extensible platform for business process automation with BPMN 2.0 and Java.
+      <a href="http://camunda.com">Camunda</a> is a company with a long track record in BPM. For more than eight years we have been helping customers all over the world to apply business process management (BPM) in an effective way. In 2013 we launched <a href="http://camunda.org">Camunda</a> as an open, extensible platform for business process automation with BPMN 2.0 and Java.
     </p>
 
     <p>


### PR DESCRIPTION
* In april 2022, Camunda will be marketed as source-available company
* Hence I am removing the "Camunda as open-source" company statement.
  This will ensure Camunda is consistently represented on public
websites.
* Changed initiated by Lana G. (Product Marketing)
* Additional changes might follow (e.g., remove Java focus, brand Camunda as "process orchestration" company)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
