### PR TITLE
feat: add ES2018 migration blog post

### DIFF
--- a/src/blog/2022/009-es2018.md
+++ b/src/blog/2022/009-es2018.md
@@ -1,6 +1,6 @@
 ---
 
-title: Migration To ES2018
+title: Hello ES2018, Hello Modern JavaScript
 description: "Introducing bpmn-js@10, diagram-js@9, and dmn-js@13: The releases include migration of the core libraries to the modern syntax of ES2018."
 layout: blogpost.hbs
 slug: 2022-core-libraries-migrated-to-es2018
@@ -16,18 +16,18 @@ releases:
 ---
 
 <p class="introduction">
-  We are happy to announce the latest releases of our modeling toolkit which ship with modern JavaScript syntax, namely ES2018.
+  We are happy to announce the latest releases of our modeling toolkits. These new major versions incorporate a single change: We ship them with modern JavaScript syntax, namely ES2018, and browser features.
 </p>
 
 <!-- continue -->
 
-The releases introduce modern language constructs to the codebase, i.e. async/await, ES6-style classes, as well as rest/spread operator. The target runtime of the libraries is ES2018 from now on, and the bundled output will use ES2018 syntax and features.
+The releases introduce modern language constructs to the codebase, i.e. async/await, ES6-style classes, as well as rest/spread operator. The target runtime of the libraries is ES2018 from now on, and the bundled output will use ES2018 syntax and features. Furthermore, we stop shipping [shims/polyfills](https://developer.mozilla.org/en-US/docs/Glossary/Shim) to support long dead browsers (bye bye Internet Explorer!).
 
-For the users, this will result in smaller bundles, and can also improve the performance as modern language features won't be polyfilled. Also, for both the bpmn.io team as well as the contributors, it will be easier to develop the libraries as we can now use the new language features freely.
+For library users, this results in smaller bundles. Performance improves where modern language features are no longer polyfilled. For us and our contributors this means a productivity boost: We may now use modern language features without transpilation and debug the real thing in case of an error, not a source-mapped representation.
 
 ## Migration
 
-You don't have to do anything to prepare for the new versions unless you require support for ancient browsers such as Internet Explorer 11. Also, if you already transpile your code using tools such as [Babel](https://babeljs.io/), no additional steps are required.
+You don't have to do anything to prepare for the new versions unless you require support for dead browsers such as Internet Explorer. Also, if you already transpile your code using tools such as [Babel](https://babeljs.io/), no additional steps are required.
 
 Otherwise, you need to setup a transpilation step in your bundler pipeline. A common way to do this is to use [Babel](https://babeljs.io/), for example via [a Babel plugin](https://www.npmjs.com/package/@rollup/plugin-babel) in your [rollup](https://rollupjs.org/) configuration:
 
@@ -46,9 +46,7 @@ export default {
 };
 ```
 
-Cf. [rollup guide](https://rollupjs.org/guide/en/#babel).
-
-If your bundler of choice is [webpack](https://webpack.js.org/), check out [the bundling example](https://github.com/bpmn-io/bpmn-js-examples/pull/184).
+Checkout the full [rollup guide on using Babel](https://rollupjs.org/guide/en/#babel). If your bundler of choice is [webpack](https://webpack.js.org/), check out [the bundling example](https://github.com/bpmn-io/bpmn-js-examples/pull/184).
 
 ## Wrapping up
 

--- a/src/blog/2022/009-es2018.md
+++ b/src/blog/2022/009-es2018.md
@@ -6,7 +6,7 @@ layout: blogpost.hbs
 slug: 2022-core-libraries-migrated-to-es2018
 author:
 - Maciej Barelkowski <https://github.com/barmac>
-published: 2022-09-14 12:00
+published: 2022-09-15 12:00
 
 releases:
   - 'bpmn-js@10.0.0'

--- a/src/blog/2022/009-es2018.md
+++ b/src/blog/2022/009-es2018.md
@@ -21,15 +21,15 @@ releases:
 
 <!-- continue -->
 
-The releases introduce modern language constructs to the codebase, i.e. async/await, ES6-style classes, as well as rest/spread operator. The target runtime of the libraries is ES2018 from now on, and the bundled output will use ES2018 syntax and features. Furthermore, we stop shipping [shims/polyfills](https://developer.mozilla.org/en-US/docs/Glossary/Shim) to support long dead browsers (bye bye Internet Explorer!).
+The releases introduce modern language constructs to the codebase, i.e., async/await, ES6-style classes, and rest/spread operator. The target runtime of the libraries is ES2018 from now on, and the bundled output will use ES2018 syntax and features. Furthermore, we stop shipping [shims/polyfills](https://developer.mozilla.org/en-US/docs/Glossary/Shim) to support long-dead browsers (bye-bye Internet Explorer!).
 
-For library users, this results in smaller bundles. Performance improves where modern language features are no longer polyfilled. For us and our contributors this means a productivity boost: We may now use modern language features without transpilation and debug the real thing in case of an error, not a source-mapped representation.
+For library users, this results in smaller bundles. Performance improves where modern language features are no longer polyfilled. This means a productivity boost for us and our contributors : We may now use modern language features without transpilation and debug the real thing in case of an error, not a source-mapped representation.
 
 ## Migration
 
-You don't have to do anything to prepare for the new versions unless you require support for dead browsers such as Internet Explorer. Also, if you already transpile your code using tools such as [Babel](https://babeljs.io/), no additional steps are required.
+You don't have to do anything to prepare for the new versions unless you require support for dead browsers such as Internet Explorer. Also, no additional steps are required, if you already transpile your code using tools such as [Babel](https://babeljs.io/).
 
-Otherwise, you need to setup a transpilation step in your bundler pipeline. A common way to do this is to use [Babel](https://babeljs.io/), for example via [a Babel plugin](https://www.npmjs.com/package/@rollup/plugin-babel) in your [rollup](https://rollupjs.org/) configuration:
+Otherwise, you need to setup a transpilation step in your bundler pipeline. A common way to do this is to use [Babel](https://babeljs.io/), for example, via [a Babel plugin](https://www.npmjs.com/package/@rollup/plugin-babel) in your [rollup](https://rollupjs.org/) configuration:
 
 ```javascript
 // rollup.config.js
@@ -46,7 +46,7 @@ export default {
 };
 ```
 
-Checkout the full [rollup guide on using Babel](https://rollupjs.org/guide/en/#babel). If your bundler of choice is [webpack](https://webpack.js.org/), check out [the bundling example](https://github.com/bpmn-io/bpmn-js-examples/pull/184).
+Check out the complete [rollup guide on using Babel](https://rollupjs.org/guide/en/#babel). If your bundler of choice is [webpack](https://webpack.js.org/), check out [the bundling example](https://github.com/bpmn-io/bpmn-js-examples/pull/184).
 
 ## Wrapping up
 

--- a/src/blog/2022/009-es2018.md
+++ b/src/blog/2022/009-es2018.md
@@ -52,7 +52,4 @@ If your bundler of choice is [webpack](https://webpack.js.org/), check out [the 
 
 Did we miss anything? Did you spot a bug, or would you like to suggest an improvement?
 
-Reach out to us via [our forums](https://forum.bpmn.io/), tweet us [@bpmn_io](https://twitter.com/bpmn_io) or file an issue you found in the respective issue tracker:
-* [the bpmn-js issue tracker](https://github.com/bpmn-io/bpmn-js/issues),
-* [the dmn-js issue tracker](https://github.com/bpmn-io/dmn-js/issues),
-* [the diagram-js issue tracker](https://github.com/bpmn-io/diagram-js/issues).
+Reach out to us via [our forums](https://forum.bpmn.io/), tweet us [@bpmn_io](https://twitter.com/bpmn_io) or file any issue you found in the respective issue trackers for [bpmn-js](https://github.com/bpmn-io/bpmn-js/issues), [dmn-js](https://github.com/bpmn-io/dmn-js/issues), or [diagram-js](https://github.com/bpmn-io/diagram-js/issues).

--- a/src/blog/2022/009-es2018.md
+++ b/src/blog/2022/009-es2018.md
@@ -25,7 +25,7 @@ The releases introduce modern language constructs to the codebase, i.e. async/aw
 
 ## Migration
 
-If your application does not target unsupported browsers (mainly Internet Explorer 11), you don't need to do anything to prepare for the new versions. Also, if you already transpile your code, no additional steps should be required.
+You don't have to do anything to prepare for the new versions unless you require support for ancient browsers such as Internet Explorer 11. Also, if you already transpile your code using tools such as [Babel](https://babeljs.io/), no additional steps are required.
 
 Otherwise, you need to setup a transpilation step in your bundler pipeline. A common way to do this is to use [Babel](https://babeljs.io/), for example via [a Babel plugin](https://www.npmjs.com/package/@rollup/plugin-babel) in your [rollup](https://rollupjs.org/) configuration:
 

--- a/src/blog/2022/009-es2018.md
+++ b/src/blog/2022/009-es2018.md
@@ -21,7 +21,9 @@ releases:
 
 <!-- continue -->
 
-The releases introduce modern language constructs to the codebase, i.e. async/await, ES6-style classes, as well as rest/spread operator. We believe this will allow reduce the burden on contributors who won't need to limit to ES5 syntax anymore.
+The releases introduce modern language constructs to the codebase, i.e. async/await, ES6-style classes, as well as rest/spread operator. The target runtime of the libraries is ES2018 from now on, and the bundled output will use ES2018 syntax and features.
+
+For the users, this will result in smaller bundles, and can also improve the performance as modern language features won't be polyfilled. Also, for both the bpmn.io team as well as the contributors, it will be easier to develop the libraries as we can now use the new language features freely.
 
 ## Migration
 

--- a/src/blog/2022/009-es2018.md
+++ b/src/blog/2022/009-es2018.md
@@ -1,6 +1,6 @@
 ---
 
-title: Core Libraries Migrated To ES2018
+title: Migration To ES2018
 description: "Introducing bpmn-js@10, diagram-js@9, and dmn-js@13: The releases include migration of the core libraries to the modern syntax of ES2018."
 layout: blogpost.hbs
 slug: 2022-core-libraries-migrated-to-es2018

--- a/src/blog/2022/009-es2018.md
+++ b/src/blog/2022/009-es2018.md
@@ -1,0 +1,58 @@
+---
+
+title: Core Libraries Migrated To ES2018
+description: "Introducing bpmn-js@10, diagram-js@9, and dmn-js@13: The releases include migration of the core libraries to the modern syntax of ES2018."
+layout: blogpost.hbs
+slug: 2022-core-libraries-migrated-to-es2018
+author:
+- Maciej Barelkowski <https://github.com/barmac>
+published: 2022-09-14 12:00
+
+releases:
+  - 'bpmn-js@10.0.0'
+  - 'diagram-js@9.0.0'
+  - 'dmn-js@13.0.0'
+
+---
+
+<p class="introduction">
+  We are happy to announce the latest releases of our modeling toolkit which ship with modern JavaScript syntax, namely ES2018.
+</p>
+
+<!-- continue -->
+
+The releases introduce modern language constructs to the codebase, i.e. async/await, ES6-style classes, as well as rest/spread operator. We believe this will allow reduce the burden on contributors who won't need to limit to ES5 syntax anymore.
+
+## Migration
+
+If your application does not target unsupported browsers (mainly Internet Explorer 11), you don't need to do anything to prepare for the new versions. Also, if you already transpile your code, no additional steps should be required.
+
+Otherwise, you need to setup a transpilation step in your bundler pipeline. A common way to do this is to use [Babel](https://babeljs.io/), for example via [a Babel plugin](https://www.npmjs.com/package/@rollup/plugin-babel) in your [rollup](https://rollupjs.org/) configuration:
+
+```javascript
+// rollup.config.js
+import resolve from '@rollup/plugin-node-resolve';
+import babel from '@rollup/plugin-babel';
+
+export default {
+  input: 'src/main.js',
+  output: {
+    file: 'bundle.js',
+    format: 'cjs'
+  },
+  plugins: [resolve(), babel({ babelHelpers: 'bundled' })]
+};
+```
+
+Cf. [rollup guide](https://rollupjs.org/guide/en/#babel).
+
+If your bundler of choice is [webpack](https://webpack.js.org/), check out [the bundling example](https://github.com/bpmn-io/bpmn-js-examples/pull/184).
+
+## Wrapping up
+
+Did we miss anything? Did you spot a bug, or would you like to suggest an improvement?
+
+Reach out to us via [our forums](https://forum.bpmn.io/), tweet us [@bpmn_io](https://twitter.com/bpmn_io) or file an issue you found in the respective issue tracker:
+* [the bpmn-js issue tracker](https://github.com/bpmn-io/bpmn-js/issues),
+* [the dmn-js issue tracker](https://github.com/bpmn-io/dmn-js/issues),
+* [the diagram-js issue tracker](https://github.com/bpmn-io/diagram-js/issues).


### PR DESCRIPTION
This PR adds a blog post on the ES2018 syntax migration in our core libraries.