### PR TITLE
chore: link mastodon instead of Twitter

### DIFF
--- a/src/templates/partials/footer.hbs
+++ b/src/templates/partials/footer.hbs
@@ -10,7 +10,7 @@ component: footer
       <li><a href="{{relative page.dest "dist/roadmap"}}">Roadmap</a></li>
       <li><a href="https://forum.bpmn.io">Forum</a></li>
       <li><a href="https://github.com/bpmn-io">GitHub</a></li>
-      <li><a href="https://twitter.com/bpmn_io">Twitter</a></li>
+      <li><a href="https://fosstodon.org/@bpmn_io">Mastodon</a></li>
       <li><a href="http://demo.bpmn.io">Online Demo</a></li>
       <li><a href="https://camunda.com/platform/modeler/">Camunda Modeler</a></li>
     </ul>


### PR DESCRIPTION
We're not maintaining our X (formerly twitter) account anymore.