### PR TITLE
feat(blog): add callback style API removal blog

### DIFF
--- a/src/blog/2023/009-removing-legacy-callback-style-apis.md
+++ b/src/blog/2023/009-removing-legacy-callback-style-apis.md
@@ -1,0 +1,40 @@
+---
+
+title: Dropping Legacy Callback Style APIs
+description: "Recent and upcoming releases will fully remove long deprecated callback style APIs for our BPMN and DMN toolkits."
+layout: blogpost.hbs
+slug: 2023-dropping-legacy-callback-style-apis
+url: https://bpmn.io/blog/posts/2023-dropping-legacy-callback-style-apis.html
+author:
+- Nico Rehwaldt <https://github.com/nikku>
+published: 2023-01-05 12:00
+
+releases:
+  - 'bpmn-js@14.0.0'
+
+---
+
+<p class="introduction">
+  With the recent [bpmn-js@14](https://github.com/bpmn-io/bpmn-js) major release we removed callback style APIs from our BPMN toolkit. We'll follow-up with other toolkits in the near future.
+</p>
+
+<!-- continue -->
+
+If you still work with the deprecated callbacks, ensure to move over to the web platform friendly `Promise`-based APIs:
+
+```javascript
+const xml = '...'; // my BPMN 2.0 xml
+const viewer = new BpmnJS({
+  container: 'body'
+});
+
+try {
+  const { warnings } = await viewer.importXML(xml);
+
+  console.log('rendered');
+} catch (err) {
+  console.log('error rendering', err);
+}
+```
+
+Reach out to us via [our forums](https://forum.bpmn.io/), follow our updates via [@bpmn_io@fosstodon.org](https://fosstodon.org/@bpmn_io), and file any issue you found in the respective toolkit issue trackers.

--- a/src/blog/2023/009-removing-legacy-callback-style-apis.md
+++ b/src/blog/2023/009-removing-legacy-callback-style-apis.md
@@ -7,7 +7,7 @@ slug: 2023-dropping-legacy-callback-style-apis
 url: https://bpmn.io/blog/posts/2023-dropping-legacy-callback-style-apis.html
 author:
 - Nico Rehwaldt <https://github.com/nikku>
-published: 2023-01-05 12:00
+published: 2023-08-16 12:00
 
 releases:
   - 'bpmn-js@14.0.0'


### PR DESCRIPTION
Post mortem publish for until now not publicly announced callback drop.

![image](https://github.com/bpmn-io/bpmn.io/assets/58601/3d1d3ef0-2f3e-498d-a197-e646e437aaa6)
