### PR TITLE
chore: allow to link to toolkit sections

### DIFF
--- a/src/pages/toolkit/bpmn-js/index.hbs
+++ b/src/pages/toolkit/bpmn-js/index.hbs
@@ -31,7 +31,7 @@ layout: toolkit.hbs
 
 <div class="bi-features">
   <div class="container">
-    <h2>BPMN everywhere, for everyone</h2>
+    <h2 id="mission">BPMN everywhere, for everyone</h2>
     <p class="lead">
       Create, embed and extend BPMN diagrams in your Browser.
       Use it standalone or integrate it into your application.
@@ -68,7 +68,7 @@ layout: toolkit.hbs
 
 <div class="bi-features">
   <div class="container">
-    <h2>Add BPMN diagrams to your application</h2>
+    <h2 id="usage">Add BPMN diagrams to your application</h2>
 
     <p class="lead">
       Embed BPMN diagrams in your application with a few lines of code.
@@ -102,7 +102,7 @@ layout: toolkit.hbs
 
 <div class="bi-features">
   <div class="container">
-    <h2>Make it yours</h2>
+    <h2 id="extending">Make it yours</h2>
 
     <p class="lead">
       bpmn-js is built for extensibility. <a href="https://github.com/bpmn-io/bpmn-js-nyan">Customize</a> or <a href="https://github.com/bpmn-io/bpmn-js-examples/tree/main/custom-elements">extend</a> the toolkit to suit your needs.

--- a/src/pages/toolkit/cmmn-js/index.hbs
+++ b/src/pages/toolkit/cmmn-js/index.hbs
@@ -44,7 +44,7 @@ layout: toolkit.hbs
 
 <div class="bi-features">
   <div class="container">
-    <h2>Add CMMN diagrams to your application</h2>
+    <h2 id="usage">Add CMMN diagrams to your application</h2>
 
     <p class="lead">
       Embed CMMN diagrams in your application with a few lines of code.

--- a/src/pages/toolkit/dmn-js/index.hbs
+++ b/src/pages/toolkit/dmn-js/index.hbs
@@ -31,7 +31,7 @@ layout: toolkit.hbs
 
 <div class="bi-features">
   <div class="container">
-    <h2>Visual Business Rules everywhere</h2>
+    <h2 id="mission">Visual Business Rules everywhere</h2>
     <p class="lead">
       View, create and edit DMN decision tables, literal expressions and decision requirement diagrams in your browser.
       Use <a href="https://github.com/bpmn-io/dmn-js">dmn-js</a> standalone or embed it into your application.
@@ -43,7 +43,7 @@ layout: toolkit.hbs
 
 <div class="bi-features">
   <div class="container">
-    <h2>Add DMN diagrams to your application</h2>
+    <h2 id="usage">Add DMN diagrams to your application</h2>
 
     <p class="lead">
       Embed DMN diagrams and decision tables to your application with a few lines of code.

--- a/src/pages/toolkit/form-js/index.hbs
+++ b/src/pages/toolkit/form-js/index.hbs
@@ -31,7 +31,7 @@ layout: toolkit.hbs
 
 <div class="bi-features">
   <div class="container">
-    <h2>Create forms visually</h2>
+    <h2 id="mission">Create forms visually</h2>
     <p class="lead">
       Assemble your forms using our intuitive <a href="https://github.com/bpmn-io/form-js#builder">form builder</a>.
 
@@ -44,7 +44,7 @@ layout: toolkit.hbs
 
 <div class="bi-features">
   <div class="container">
-    <h2>Render your forms anywhere</h2>
+    <h2 id="usage">Render your forms anywhere</h2>
 
     <p class="lead">
       Embed our <a href="https://github.com/bpmn-io/form-js#viewer">form viewer</a> to render your JSON-based forms in any webpage.


### PR DESCRIPTION
As identified in a quick session today we cannot link to individual parts of our toolkit pages. This PR addresses this by introducing section anchors.